### PR TITLE
Add FindByAccount for Transactions resource

### DIFF
--- a/lib/unit-ruby/transaction.rb
+++ b/lib/unit-ruby/transaction.rb
@@ -9,5 +9,6 @@ module Unit
     attribute :created_at, Types::DateTime, readonly: true
 
     include ResourceOperations::List
+    include ResourceOperations::FindByAccount
   end
 end

--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -16,6 +16,20 @@ module Unit
       end
     end
 
+    module FindByAccount
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def find_by_account(account_id:, id:)
+          located_resource = connection.get("/accounts/#{account_id}#{resource_path(id)}")
+
+          build_resource_from_json_api(located_resource)
+        end
+      end
+    end
+
     module Create
       def self.included(klass)
         klass.extend(ClassMethods)


### PR DESCRIPTION
Fetching transactions by id requires prefixing by the account: https://docs.unit.co/transactions#get-specific-transaction

I'm not sure if there are other prefixed lookups, so there might be a more generic way to handle this (instead of just hardcoding `/accounts` as the prefix, but this quick fix unblocks the Transactions syncing right now :)