### PR TITLE
Allow filters on find requests

### DIFF
--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -8,8 +8,10 @@ module Unit
       end
 
       module ClassMethods
-        def find(id)
-          located_resource = connection.get(resource_path(id))
+        # @param where [Hash] Optional. Filters to apply.
+        def find(id, where: nil)
+          params = { filter: where }.compact
+          located_resource = connection.get(resource_path(id), params)
 
           build_resource_from_json_api(located_resource)
         end


### PR DESCRIPTION
Authorizations GET by id allows passing in "filter" that includes more resources: https://docs.unit.co/cards-authorizations#get-authorization-by-id

ex: `Unit::Authorization.find('1701715', where: {includeNonAuthorized: true})`