### PR TITLE
ACH counterparty

### DIFF
--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -20,6 +20,7 @@ require 'unit-ruby/types/integer'
 require 'unit-ruby/types/phone'
 require 'unit-ruby/types/string'
 
+require 'unit-ruby/ach_counterparty'
 require 'unit-ruby/ach_payment'
 require 'unit-ruby/application_form'
 require 'unit-ruby/approve_authorization_request'

--- a/lib/unit-ruby/ach_counterparty.rb
+++ b/lib/unit-ruby/ach_counterparty.rb
@@ -1,0 +1,24 @@
+module Unit
+  class AchCounterparty < APIResource
+    path '/counterparties'
+
+    attribute :name, Types::String
+    attribute :plaid_processor_token, Types::String
+    attribute :type, Types::String
+    attribute :verify_name, Types::Boolean # Optional
+    attribute :permissions, Types::String # Optional
+    attribute :tags, Types::Hash # Optional
+    attribute :idempotency_key, Types::String # Optional
+
+    attribute :bank, Types::String, readonly: true
+    attribute :routing_number, Types::String, readonly: true
+    attribute :account_number, Types::String, readonly: true
+    attribute :account_type, Types::String, readonly: true
+
+    belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+
+    include ResourceOperations::Find
+    include ResourceOperations::List
+    include ResourceOperations::Create
+  end
+end


### PR DESCRIPTION
https://docs.unit.co/payments-counterparties#create-counterparty-with-plaid-token

There's a collision on AchPayment resource with the inline counterparty type, so didn't add the belongs_to there.