### PR TITLE
Automatically generate idempotency key if not set during initialization

### DIFF
--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 require 'unit-ruby/util/connection'
 require 'unit-ruby/util/error'
 require 'unit-ruby/util/api_resource'

--- a/lib/unit-ruby/ach_counterparty.rb
+++ b/lib/unit-ruby/ach_counterparty.rb
@@ -8,7 +8,7 @@ module Unit
     attribute :verify_name, Types::Boolean # Optional
     attribute :permissions, Types::String # Optional
     attribute :tags, Types::Hash # Optional
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
 
     attribute :bank, Types::String, readonly: true
     attribute :routing_number, Types::String, readonly: true

--- a/lib/unit-ruby/ach_payment.rb
+++ b/lib/unit-ruby/ach_payment.rb
@@ -7,7 +7,7 @@ module Unit
     attribute :counterparty, Types::Counterparty # For inline Counterparties
     attribute :description, Types::String
     attribute :addenda, Types::String
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :tags, Types::Hash # Optional
     attribute :verify_counterparty_balance, Types::Hash # Optional
 

--- a/lib/unit-ruby/batch_release.rb
+++ b/lib/unit-ruby/batch_release.rb
@@ -8,7 +8,7 @@ module Unit
     attribute :sender_address, Types::Address
     attribute :sender_account_number, Types::String
     attribute :tags, Types::Hash # Optional
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
 
     belongs_to :batch_account, resource_type: "batchAccount", class_name: 'Unit::DepositAccount'
     belongs_to :receiver, resource_type: "depositAccount", class_name: 'Unit::DepositAccount'

--- a/lib/unit-ruby/book_payment.rb
+++ b/lib/unit-ruby/book_payment.rb
@@ -6,7 +6,7 @@ module Unit
     attribute :description, Types::String
     attribute :transaction_summary_override, Types::String # Optional
     attribute :tags, Types::Hash # Optional
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
 
     belongs_to :account, resource_type: "depositAccount", class_name: 'Unit::DepositAccount'
     belongs_to :counterparty_account, resource_type: "depositAccount", class_name: 'Unit::DepositAccount'

--- a/lib/unit-ruby/deposit_account.rb
+++ b/lib/unit-ruby/deposit_account.rb
@@ -3,7 +3,7 @@ module Unit
     path '/accounts'
 
     attribute :deposit_product, Types::String # The name of the deposit product
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :tags, Types::Hash # Optional
 
     attribute :created_at, Types::DateTime, readonly: true

--- a/lib/unit-ruby/individual_application.rb
+++ b/lib/unit-ruby/individual_application.rb
@@ -15,7 +15,7 @@ module Unit
     attribute :ein, Types::String # Optional. If the individual is a sole proprietor who has an Employer Identification Number, specify it here. Not all sole proprietors have an EIN, so this attribute is optional, even when soleProprietorship is set to true.
     attribute :dba, Types::String # Optional. If the individual is a sole proprietor who is doing business under a different name, specify it here. This attribute is optional, even when soleProprietorship is set to true.
     attribute :tags, Types::Hash # Optional. Tags that will be copied to the customer that this application creates
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :device_fingerprints, Types::Array # array of Device Fingerprint	Optional. A list of device fingerprints for fraud and risk prevention
 
     attribute :created_at, Types::DateTime, readonly: true

--- a/lib/unit-ruby/individual_customer.rb
+++ b/lib/unit-ruby/individual_customer.rb
@@ -13,7 +13,7 @@ module Unit
     attribute :dba, Types::String # Optional. If the individual is a sole proprietor who is doing business under a different name.
     attribute :sole_proprietorship, Types::Boolean
     attribute :tags, Types::Hash # Optional. Tags that will be copied to the customer that this application creates
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :risk_rate, Types::String, readonly: true
     attribute :authorized_users, Types::Array, readonly: true
     attribute :created_at, Types::DateTime, readonly: true

--- a/lib/unit-ruby/individual_debit_card.rb
+++ b/lib/unit-ruby/individual_debit_card.rb
@@ -5,7 +5,7 @@ module Unit
     attribute :shipping_address, Types::Address # Optional. Address to ship the card to. If not specified, the individual address is used.
     attribute :design, Types::String # Optional. You may omit if you only have one card design. Please contact Unit if you need multiple card designs.
     attribute :additional_embossed_text, Types::String # Optional, up to 21 characters. Use for a second cardholder name, company name, or other data to be embossed on a card.
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :tags, Types::Hash # Optional
     attribute :limits, Types::Hash # Optional
 

--- a/lib/unit-ruby/individual_virtual_debit_card.rb
+++ b/lib/unit-ruby/individual_virtual_debit_card.rb
@@ -2,7 +2,7 @@ module Unit
   class IndividualVirtualDebitCard < APIResource
     path '/cards'
 
-    attribute :idempotency_key, Types::String # Optional
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :tags, Types::Hash # Optional
     attribute :limits, Types::Hash # Optional
 

--- a/lib/unit-ruby/util/api_resource.rb
+++ b/lib/unit-ruby/util/api_resource.rb
@@ -9,6 +9,13 @@ module Unit
       attributes.each do |key, value|
         send("#{key}=", value)
       end
+
+      schema.attributes.each do |schema_attribute|
+        next unless schema_attribute.factory
+        next if send(:"#{schema_attribute.name}")
+
+        send(:"#{schema_attribute.name}=", schema_attribute.factory.call)
+      end
     end
 
     # Creates a base http connection to the API
@@ -32,8 +39,9 @@ module Unit
     # @param name [Symbol] the name of the attribute
     # @param type [Class] the object type
     # @param readonly [Boolean] excludes the attribute from the request when creating a resource
-    def self.attribute(name, type = nil, readonly: false)
-      schema.add(name, type, readonly: readonly)
+    # @param factory [Proc] called when attribute is nil during object initialization (not used when deserializing JSON API)
+    def self.attribute(name, type = nil, readonly: false, factory: nil)
+      schema.add(name, type, readonly: readonly, factory: factory)
 
       attr_accessor name
 

--- a/lib/unit-ruby/util/schema.rb
+++ b/lib/unit-ruby/util/schema.rb
@@ -1,6 +1,6 @@
 module Unit
   class Schema
-    Attribute = Struct.new(:name, :type, :readonly)
+    Attribute = Struct.new(:name, :type, :readonly, :factory)
 
     def initialize
       @attributes = []
@@ -10,8 +10,8 @@ module Unit
       attributes.map(&:name).include? name
     end
 
-    def add(name, type, readonly: false)
-      @attributes << Attribute.new(name, type, readonly)
+    def add(name, type, readonly: false, factory: nil)
+      @attributes << Attribute.new(name, type, readonly, factory)
     end
     attr_reader :attributes
   end

--- a/spec/features/ach_payment_spec.rb
+++ b/spec/features/ach_payment_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'securerandom'
 
 RSpec.describe Unit::AchPayment do
   before do
@@ -26,7 +25,7 @@ RSpec.describe Unit::AchPayment do
       direction: 'Credit',
       description: 'MyCompany',
       addenda: 'MyCompany monthly payment',
-      idempotency_key: SecureRandom.uuid,
+      idempotency_key: SecureRandom.base64,
       counterparty: counterparty,
       account: deposit_account,
       tags: { tag1: 'value1', tag2: 'value2' }


### PR DESCRIPTION
This gem has Faraday middleware to automatically retry requests 3 times but without this change, requires every caller to specify an idempotency key to make this safe. Instead, do the sane thing and generate one to make the occasional network glitch papered over by a retry safe.

https://github.com/thatch-health/unit-ruby/blob/923f46bf9f64c667910adbab3f4b06e032e6bcbb/lib/unit-ruby/util/connection.rb#L14-L19

Testing:
```
Unit::AchPayment.new.as_json_api
=> {:amount=>nil,
 :direction=>nil,
 :counterparty=>nil,
 :description=>nil,
 :addenda=>nil,
 :idempotency_key=>"1b90af53-1836-4cdb-be5d-a9f482ac9ca0",
 :tags=>{},
 :verify_counterparty_balance=>{}}
```

```
Unit::AchPayment.find 1300314
=> #<Unit::AchPayment:0x000000010ebba698
 @addenda=nil,
 @amount=345,
 @counterparty=#<Unit::Types::Counterparty:0x000000010ebb8438 @account_number="1000000001", @account_type="Checking", @name="Unit", @routing_number="711115678">,
 @created_at="2022-11-23T18:24:45+00:00",
 @description="should sec",
 @direction="Credit",
 @dirty_attributes=[],
 @id="1300314",
 @idempotency_key=nil,
```