### PR TITLE
Add AccountEndOfDay to allow retrieving balance history

### DIFF
--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -24,6 +24,7 @@ require 'unit-ruby/types/string'
 
 require 'unit-ruby/ach_counterparty'
 require 'unit-ruby/ach_payment'
+require 'unit-ruby/account_end_of_day'
 require 'unit-ruby/application_form'
 require 'unit-ruby/approve_authorization_request'
 require 'unit-ruby/authorization'

--- a/lib/unit-ruby/account_end_of_day.rb
+++ b/lib/unit-ruby/account_end_of_day.rb
@@ -1,0 +1,15 @@
+module Unit
+  class AccountEndOfDay < APIResource
+    path '/account-end-of-day'
+
+    attribute :date, Types::DateTime, readonly: true
+    attribute :balance, Types::Integer, readonly: true
+    attribute :hold, Types::Integer, readonly: true
+    attribute :available, Types::Integer, readonly: true
+
+    belongs_to :account, class_name: 'Unit::DepositAccount'
+    belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+
+    include ResourceOperations::List
+  end
+end


### PR DESCRIPTION
API: https://docs.unit.co/resources/#account-end-of-day
APIResource: https://docs.unit.co/resources/#account-end-of-day

More detail on how to test: https://www.notion.so/thatchhealth/Unit-ad5c5784e4bd47aeb3df5f97a5e6fa0f?pvs=4#8b5792a3d05b4c0394a8d4f035d24016

Tested via console:
```
irb(main):002:0> Unit::AccountEndOfDay.list(where: {accountId: '701839', since: '2023-05-01', until: '2023-05-01'})
=>
[#<Unit::AccountEndOfDay:0x000000011aaf3cf8
  @available=66326,
  @balance=66659,
  @date="2023-05-01T00:00:00+00:00",
  @dirty_attributes=[],
  @hold=333,
  @id="399828885",
  @raw_data=
   {:type=>"accountEndOfDay",
    :id=>"399828885",
    :attributes=>
     {:date=>"2023-05-01",
      :balance=>66659,
      :available=>66326,
      :hold=>333,
      :overdraft_limit=>0},
    :relationships=>
     {:customer=>{:data=>{:type=>"customer", :id=>"504976"}},
      :account=>{:data=>{:type=>"account", :id=>"701839"}}}},
  @relationships=
   {:customer=>{:data=>{:type=>"customer", :id=>"504976"}},
    :account=>{:data=>{:type=>"account", :id=>"701839"}}},
  @type="accountEndOfDay">]
  ```