### PR TITLE
adds the ability to pass additional headers with each resource request

### DIFF
--- a/lib/unit-ruby/application_form.rb
+++ b/lib/unit-ruby/application_form.rb
@@ -2,6 +2,7 @@ module Unit
   class ApplicationForm < APIResource
     path '/application-forms'
 
+    attribute :idempotency_key, Types::String # required for V2024_06 requests
     attribute :tags, Types::Hash # Optional
     attribute :allowed_application_types, Types::Array # Optional. Array of Individual, Business or SoleProprietorship.
     attribute :applicant_details, Types::ApplicationFormPrefill # Optional. Add data that is already known about the end-customer to be auto populated on the form.

--- a/lib/unit-ruby/application_form.rb
+++ b/lib/unit-ruby/application_form.rb
@@ -2,7 +2,7 @@ module Unit
   class ApplicationForm < APIResource
     path '/application-forms'
 
-    attribute :idempotency_key, Types::String # required for V2024_06 requests
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
     attribute :tags, Types::Hash # Optional
     attribute :allowed_application_types, Types::Array # Optional. Array of Individual, Business or SoleProprietorship.
     attribute :applicant_details, Types::ApplicationFormPrefill # Optional. Add data that is already known about the end-customer to be auto populated on the form.

--- a/lib/unit-ruby/util/connection.rb
+++ b/lib/unit-ruby/util/connection.rb
@@ -23,8 +23,12 @@ module Unit
     # Executes a GET request to the API
     #
     # @return the resource (or array of resources) returned from the API
-    def get(path, params = nil)
-      response = connection.get(path, params)
+    def get(path, params = nil, headers = {})
+      response = connection.get do |req|
+        req.url path
+        req.headers.merge!(headers)
+        req.params = params
+      end
 
       handle_errors(response)
 
@@ -34,9 +38,10 @@ module Unit
     # Executes a POST request to the API
     #
     # @return [Unit::APIResource] a new instance of the resource
-    def post(path, data = nil)
+    def post(path, data = nil, headers = {})
       response = connection.post do |req|
         req.url path
+        req.headers.merge!(headers)
         req.headers['Content-Type'] = 'application/vnd.api+json'
         req.body = data.deep_transform_keys! { |key| key.to_s.camelize(:lower) } if data
       end
@@ -47,9 +52,10 @@ module Unit
     end
 
     # Executes a PATCH request to the API
-    def patch(path, data = nil)
+    def patch(path, data = nil, headers = {})
       response = connection.patch do |req|
         req.url path
+        req.headers.merge!(headers)
         req.headers['Content-Type'] = 'application/vnd.api+json'
         req.body = data.deep_transform_keys! { |key| key.to_s.camelize(:lower) } if data
       end

--- a/lib/unit-ruby/util/connection.rb
+++ b/lib/unit-ruby/util/connection.rb
@@ -24,11 +24,7 @@ module Unit
     #
     # @return the resource (or array of resources) returned from the API
     def get(path, params = nil, headers = {})
-      response = connection.get do |req|
-        req.url path
-        req.headers.merge!(headers)
-        req.params = params
-      end
+      response = connection.get(path, params, headers)
 
       handle_errors(response)
 

--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -40,10 +40,12 @@ module Unit
       end
 
       module ClassMethods
-        def create(options: {}, **attributes)
+        def create(attributes)
           id = attributes.fetch(:id, nil)
-          resource = new(attributes.without(:id))
+          options = attributes.fetch(:options, {})
           headers = options.fetch(:headers, {})
+          
+          resource = new(attributes.without(:id, :options))
 
           data = {
             type: resource.resource_type,

--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -38,7 +38,7 @@ module Unit
       end
 
       module ClassMethods
-        def create(attributes, headers: {})
+        def create(headers: {}, **attributes)
           id = attributes.fetch(:id, nil)
           resource = new(attributes.without(:id))
 

--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -9,7 +9,7 @@ module Unit
 
       module ClassMethods
         # @param where [Hash] Optional. Filters to apply.
-        def find(id, options: {})
+        def find(id, where: nil, options: {})
           headers = options.fetch(:headers, {})
           params = { filter: where }.compact
           located_resource = connection.get(resource_path(id), params, headers)

--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -9,7 +9,8 @@ module Unit
 
       module ClassMethods
         # @param where [Hash] Optional. Filters to apply.
-        def find(id, where: nil, headers: {})
+        def find(id, options: {})
+          headers = options.fetch(:headers, {})
           params = { filter: where }.compact
           located_resource = connection.get(resource_path(id), params, headers)
 
@@ -24,7 +25,8 @@ module Unit
       end
 
       module ClassMethods
-        def find_by_account(account_id:, id:, headers: {})
+        def find_by_account(account_id:, id:, options: {})
+          headers = options.fetch(:headers, {})
           located_resource = connection.get("/accounts/#{account_id}#{resource_path(id)}", nil, headers)
 
           build_resource_from_json_api(located_resource)
@@ -38,9 +40,10 @@ module Unit
       end
 
       module ClassMethods
-        def create(headers: {}, **attributes)
+        def create(options: {}, **attributes)
           id = attributes.fetch(:id, nil)
           resource = new(attributes.without(:id))
+          headers = options.fetch(:headers, {})
 
           data = {
             type: resource.resource_type,
@@ -64,7 +67,8 @@ module Unit
       end
 
       module ClassMethods
-        def bulk_create(attributes_list, headers: {})
+        def bulk_create(attributes_list, options: {})
+          headers = options.fetch(:headers, {})
           data_list = attributes_list.map do |attributes|
             resource = new(attributes.without(:id))
 
@@ -100,7 +104,8 @@ module Unit
         # @param limit	[Integer] Optional. Maximum number of resources that will be returned. Maximum is 1000 resources.
         # @param offset	[Integer] Optional. Number of resources to skip
         # @param sort [String] Optional. sort: 'createdAt' for ascending order or sort: '-createdAt' (leading minus sign) for descending order
-        def list(where: {}, limit: 100, offset: 0, sort: nil, headers: {})
+        def list(where: {}, limit: 100, offset: 0, sort: nil, options: {})
+          headers = options.fetch(:headers, {})
           params = { filter: where, page: { offset: offset, limit: limit },
                      sort: sort }.compact
           resources = connection.get(resources_path, params, headers)
@@ -111,7 +116,8 @@ module Unit
     end
 
     module Save
-      def save(headers: {})
+      def save(options: {})
+        headers = options.fetch(:headers, {})
         updated_resource = self.class.connection.patch(
           resource_path,
           {


### PR DESCRIPTION
We need to start passing the `X-Accept-Version` header in order to migrate to the White-Label Application Form flow: https://www.unit.co/docs/white-label-uis/white-label-application-form/#white-labeling-and-customization.

See https://github.com/thatch-health/thatch/pull/6656 for how this would be implemented in practice.