### PR TITLE
Add wire payment support

### DIFF
--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -21,6 +21,7 @@ require 'unit-ruby/types/hash'
 require 'unit-ruby/types/integer'
 require 'unit-ruby/types/phone'
 require 'unit-ruby/types/string'
+require 'unit-ruby/types/wire_counterparty'
 
 require 'unit-ruby/ach_counterparty'
 require 'unit-ruby/ach_payment'
@@ -46,6 +47,7 @@ require 'unit-ruby/purchase_authorization_request'
 require 'unit-ruby/statement'
 require 'unit-ruby/transaction'
 require 'unit-ruby/version'
+require 'unit-ruby/wire_payment'
 
 module Unit
   # Usage:

--- a/lib/unit-ruby/types/wire_counterparty.rb
+++ b/lib/unit-ruby/types/wire_counterparty.rb
@@ -1,0 +1,35 @@
+module Unit
+  module Types
+    class WireCounterparty
+      attr_reader :routing_number, :account_number, :name, :address
+
+      def initialize(routing_number:, account_number:, name:, address:)
+        @routing_number = routing_number
+        @account_number = account_number
+        @name = name
+        @address = address
+      end
+
+      def self.cast(val)
+        return val if val.is_a? self
+        return nil if val.nil?
+
+        new(
+          routing_number: val[:routing_number],
+          account_number: val[:account_number],
+          name: val[:name],
+          address: val[:address]
+        )
+      end
+
+      def as_json_api
+        {
+          routing_number: routing_number,
+          account_number: account_number,
+          name: name,
+          address: address.as_json_api
+        }
+      end
+    end
+  end
+end

--- a/lib/unit-ruby/wire_payment.rb
+++ b/lib/unit-ruby/wire_payment.rb
@@ -1,0 +1,19 @@
+module Unit
+  class WirePayment < APIResource
+    path '/payments'
+
+    attribute :amount, Types::Integer
+    attribute :description, Types::String
+    attribute :counterparty, Types::WireCounterparty
+    attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
+    attribute :tags, Types::Hash # Optional
+
+    belongs_to :account, class_name: 'Unit::DepositAccount'
+
+    attribute :status, Types::String, readonly: true
+
+    include ResourceOperations::Find
+    include ResourceOperations::List
+    include ResourceOperations::Create
+  end
+end


### PR DESCRIPTION
This PR adds wire payment support to our Unit Ruby library, since it isn't supported out of the box.

I tested this in sandbox to the best of my ability, but we don't have wires enabled in the sandbox. I did work through a bunch of other 4xx errors from Unit before I got this one, so I believe this error only appears once most other validations have passed:

```
thatch(dev)(writable):005:0> Unit::InitiateWireFromOrgAccountToStripeIssuing.new(amount: Money.new(1, "USD")).perform.unwrap!
Performing operation Unit::InitiateWireFromOrgAccountToStripeIssuing
request: POST https://api.s.unit.sh/payments
request: {"data":{"type":"wirePayment","attributes":{"amount":100,"description":"Funds transfer","counterparty":{"routingNumber":"123456789","accountNumber":"12345678911111","name":"Stripe Payments Company","address":{"street":"354 Oyster Point Blvd","city":"South San Francisco","state":"CA","postalCode":"94080","country":"US"}},"idempotencyKey":"wire_from_org_account_to_stripe_issuing_ca807f28-82c8-4686-9eaa-10431fdfaed9"},"relationships":{"account":{"data":{"type":"depositAccount","id":"1576598"}}}}}
response: Status 403
app/operations/unit/initiate_wire_from_org_account_to_stripe_issuing.rb:44:in 'Unit::InitiateWireFromOrgAccountToStripeIssuing#execute': [HTTP 403] Wire payments are not enabled. (Unit::Error)
Details:
	from app/operations/base_operation.rb:30:in 'block (3 levels) in BaseOperation#perform'
	from app/operations/base_operation.rb:29:in 'block (2 levels) in BaseOperation#perform'
	from app/operations/base_operation.rb:28:in 'block in BaseOperation#perform'
	from app/operations/base_operation.rb:27:in 'BaseOperation#perform'
	from (thatch):5:in '<main>'
```

(The operation in that test will be landed in a separate PR to the `thatch` repo)