### PR TITLE
[FED-846] Reprocess Received ACH Payments

### DIFF
--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -48,6 +48,7 @@ require 'unit-ruby/statement'
 require 'unit-ruby/transaction'
 require 'unit-ruby/version'
 require 'unit-ruby/wire_payment'
+require 'unit-ruby/reprocess_received_payment'
 
 module Unit
   # Usage:

--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -48,6 +48,7 @@ require 'unit-ruby/statement'
 require 'unit-ruby/transaction'
 require 'unit-ruby/version'
 require 'unit-ruby/wire_payment'
+require 'unit-ruby/received_payment'
 require 'unit-ruby/reprocess_received_payment'
 
 module Unit

--- a/lib/unit-ruby/received_payment.rb
+++ b/lib/unit-ruby/received_payment.rb
@@ -1,0 +1,25 @@
+module Unit
+  class ReceivedPayment < APIResource
+    path '/received-payments'
+
+    attribute :created_at, Types::DateTime, readonly: true
+    attribute :status, Types::String, readonly: true
+    attribute :wasAdvanced, Types::Boolean, readonly: true
+    attribute :amount, Types::Integer, readonly: true
+    attribute :completionDate, Types::Date, readonly: true
+    attribute :companyName, Types::String, readonly: true
+    attribute :counterpartyRoutingNumber, Types::String, readonly: true
+    attribute :description, Types::String, readonly: true
+    attribute :traceNumber, Types::String, readonly: true
+    attribute :secCode, Types::String, readonly: true
+    attribute :returnCutoffTime, Types::DateTime, readonly: true
+    attribute :canBeReprocessed, Types::Boolean, readonly: true
+    attribute :tags, Types::Hash, readonly: true
+
+    belongs_to :account, class_name: 'Unit::DepositAccount'
+    belongs_to :customer, class_name: 'Unit::IndividualCustomer' # Optional
+    belongs_to :receivePaymentTransaction, 'Unit::Transaction' # Optional
+    belongs_to :paymentAdvanceTransaction, 'Unit::Transaction' # Optional
+    belongs_to :repayPaymentAdvanceTransaction, 'Unit::Transaction' # Optional
+  end
+end

--- a/lib/unit-ruby/reprocess_received_payment.rb
+++ b/lib/unit-ruby/reprocess_received_payment.rb
@@ -1,6 +1,7 @@
 module Unit
   class ReprocessReceivedPayment < APIResource
     path '/received-payments'
+    response_resource ReceivedPayment
 
     def self.resources_path(id)
       "#{super(id)}/reprocess"

--- a/lib/unit-ruby/reprocess_received_payment.rb
+++ b/lib/unit-ruby/reprocess_received_payment.rb
@@ -1,0 +1,11 @@
+module Unit
+  class ReprocessReceivedPayment < APIResource
+    path '/received-payments'
+
+    def self.resources_path(id)
+      "#{super(id)}/reprocess"
+    end
+
+    include ResourceOperations::Create
+  end
+end


### PR DESCRIPTION
This PR adds ability to hit Unit's `received-payments/{id}/reprocess` endpoint, allowing us to effectively "retry" received ACH Payments that have been `MarkedForReturn` as part of ongoing JIT ACH work.

More info on the endpoint can be found [here](https://www.unit.co/docs/api/received-ach/#reprocess-received-payment).