### PR TITLE
[Fix] Add class_name to Payment resource

### DIFF
--- a/lib/unit-ruby/received_payment.rb
+++ b/lib/unit-ruby/received_payment.rb
@@ -18,8 +18,8 @@ module Unit
 
     belongs_to :account, class_name: 'Unit::DepositAccount'
     belongs_to :customer, class_name: 'Unit::IndividualCustomer' # Optional
-    belongs_to :receivePaymentTransaction, 'Unit::Transaction' # Optional
-    belongs_to :paymentAdvanceTransaction, 'Unit::Transaction' # Optional
-    belongs_to :repayPaymentAdvanceTransaction, 'Unit::Transaction' # Optional
+    belongs_to :receivePaymentTransaction, class_name: 'Unit::Transaction' # Optional
+    belongs_to :paymentAdvanceTransaction, class_name: 'Unit::Transaction' # Optional
+    belongs_to :repayPaymentAdvanceTransaction, class_name: 'Unit::Transaction' # Optional
   end
 end


### PR DESCRIPTION
Absence of `class_name` in Payment resource `belongs_to` clauses is causing Tapioca to break.