### PR TITLE
[MM-181] Unit WalletAccount resource

### DIFF
--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -50,6 +50,7 @@ require 'unit-ruby/version'
 require 'unit-ruby/wire_payment'
 require 'unit-ruby/received_payment'
 require 'unit-ruby/reprocess_received_payment'
+require 'unit-ruby/wallet_account'
 
 module Unit
   # Usage:

--- a/lib/unit-ruby/wallet_account.rb
+++ b/lib/unit-ruby/wallet_account.rb
@@ -1,0 +1,81 @@
+module Unit
+    class WalletAccount < APIResource
+        path '/accounts'
+
+        #TODO(grant): Figure out whether Unit even supports this still or not
+        attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
+        attribute :tags, Types::Hash # Optional
+    
+        attribute :created_at, Types::DateTime, readonly: true
+        attribute :name, Types::String, readonly: true # Name of the account holder
+        attribute :routing_number, Types::String, readonly: true # Routing number of account.
+        attribute :account_number, Types::String, readonly: true # Account number, together with the routingNumber forms the identifier of the account on the ACH network.
+        attribute :wallet_terms, Types::String, readonly: true # The terms of the wallet account.
+        attribute :currency, Types::String, readonly: true # Currency of the account.
+        attribute :balance, Types::Integer, readonly: true # The balance amount (in cents). The balance represents the funds that are are currently in the account (not taking into account future commitments). The balance equals the sum of 'available' and 'hold'.
+        attribute :hold, Types::Integer, readonly: true # The hold amount (in cents). The hold represents funds that are not available for spending, typically due to an outstanding card authorization.
+        attribute :available, Types::Integer, readonly: true # The available balance for spending (in cents). Equals the balance minus the hold amount.
+        attribute :freeze_reason, Types::String, readonly: true # Optional. The reason the account was frozen, either Fraud or free-text description.
+        attribute :close_reason, Types::String, readonly: true # Optional. The reason the account was closed, either ByCustomer or Fraud.
+        attribute :fraud_status, Types::String, readonly: true # Optional. The fraud status of the account
+
+        belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+
+        include ResourceOperations::List
+        include ResourceOperations::Create
+        include ResourceOperations::Save
+        include ResourceOperations::Find
+
+        def resource_path
+            self.class.resource_path(id)
+        end
+        
+        def close(reason)
+            updated_resource = self.class.connection.post(
+                "#{resource_path}/close", 
+                {
+                data: {
+                    type: "walletAccountClose",
+                    attributes: {
+                        reason: reason,
+                    }.compact
+                }
+                }
+            )
+        
+            update_resource_from_json_api(updated_resource)
+        end
+    
+        def freeze(reason, reason_text)
+            updated_resource = self.class.connection.post(
+                "#{resource_path}/freeze",
+                {
+                data: {
+                    type: "walletAccountFreeze",
+                    attributes: {
+                        reason: reason,
+                        reasonText: reason_text,
+                    }.compact
+                }
+                }
+            )
+            update_resource_from_json_api(updated_resource)
+        end
+    
+        def unfreeze
+            updated_resource = self.class.connection.post(
+                "#{resource_path}/unfreeze"
+            )
+        
+            update_resource_from_json_api(updated_resource)
+        end
+
+        def reopen
+            updated_resource = self.class.connection.post(
+                "#{resource_path}/reopen"
+            )
+        
+            update_resource_from_json_api(updated_resource)
+        end
+    end
+end

--- a/lib/unit-ruby/wallet_account.rb
+++ b/lib/unit-ruby/wallet_account.rb
@@ -1,16 +1,13 @@
 module Unit
     class WalletAccount < APIResource
         path '/accounts'
-
-        #TODO(grant): Figure out whether Unit even supports this still or not
-        attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
-        attribute :tags, Types::Hash # Optional
     
         attribute :created_at, Types::DateTime, readonly: true
+        attribute :updated_at, Types::DateTime, readonly: true
         attribute :name, Types::String, readonly: true # Name of the account holder
         attribute :routing_number, Types::String, readonly: true # Routing number of account.
         attribute :account_number, Types::String, readonly: true # Account number, together with the routingNumber forms the identifier of the account on the ACH network.
-        attribute :wallet_terms, Types::String, readonly: true # The terms of the wallet account.
+        attribute :deposit_product, Types::String, readonly: true # The name of the deposit product
         attribute :currency, Types::String, readonly: true # Currency of the account.
         attribute :balance, Types::Integer, readonly: true # The balance amount (in cents). The balance represents the funds that are are currently in the account (not taking into account future commitments). The balance equals the sum of 'available' and 'hold'.
         attribute :hold, Types::Integer, readonly: true # The hold amount (in cents). The hold represents funds that are not available for spending, typically due to an outstanding card authorization.
@@ -18,6 +15,11 @@ module Unit
         attribute :freeze_reason, Types::String, readonly: true # Optional. The reason the account was frozen, either Fraud or free-text description.
         attribute :close_reason, Types::String, readonly: true # Optional. The reason the account was closed, either ByCustomer or Fraud.
         attribute :fraud_status, Types::String, readonly: true # Optional. The fraud status of the account
+        attribute :data_status, Types::String, readonly: true # Optional
+
+        attribute :wallet_terms, Types::String # The terms of the wallet account.
+        attribute :idempotency_key, Types::String, factory: -> { SecureRandom.uuid } # Optional
+        attribute :tags, Types::Hash # Optional
 
         belongs_to :customer, class_name: 'Unit::IndividualCustomer'
 

--- a/spec/wallet_account_spec.rb
+++ b/spec/wallet_account_spec.rb
@@ -1,0 +1,334 @@
+require 'spec_helper'
+
+RSpec.describe Unit::WalletAccount do
+  let(:wallet_terms) { 'Terms and conditions for wallet account' }
+
+  subject do
+    described_class.new(
+      wallet_terms: wallet_terms
+    )
+  end
+
+  describe 'attributes' do
+    it 'has required writable attributes' do
+      expect(subject.wallet_terms).to eq wallet_terms
+    end
+
+    it 'has optional writable attributes' do
+      account = described_class.new(
+        wallet_terms: wallet_terms,
+        tags: { key: 'value' }
+      )
+
+      expect(account.tags).to be_a(Unit::Types::Hash)
+      expect(account.tags[:key]).to eq 'value'
+    end
+
+    it 'generates idempotency_key via factory' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+
+      expect(account.idempotency_key).to be_a(String)
+      expect(account.idempotency_key.length).to be > 0
+    end
+
+    it 'has readonly attributes' do
+      # These would be set when loading from API
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+
+      expect(account).to respond_to(:created_at)
+      expect(account).to respond_to(:updated_at)
+      expect(account).to respond_to(:name)
+      expect(account).to respond_to(:routing_number)
+      expect(account).to respond_to(:account_number)
+      expect(account).to respond_to(:deposit_product)
+      expect(account).to respond_to(:currency)
+      expect(account).to respond_to(:balance)
+      expect(account).to respond_to(:hold)
+      expect(account).to respond_to(:available)
+      expect(account).to respond_to(:freeze_reason)
+      expect(account).to respond_to(:close_reason)
+      expect(account).to respond_to(:fraud_status)
+      expect(account).to respond_to(:data_status)
+    end
+  end
+
+  describe '#resource_path' do
+    it 'returns the resource path with id' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      expect(account.resource_path).to eq '/accounts/123'
+    end
+  end
+
+  describe '#close' do
+    let(:connection) { instance_double(Unit::Connection) }
+    let(:response_body) do
+      {
+        id: '123',
+        type: 'walletAccount',
+        attributes: {
+          close_reason: 'ByCustomer',
+          status: 'Closed'
+        }
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:post).and_return(response_body)
+    end
+
+    it 'calls the close endpoint with reason' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.close('ByCustomer')
+
+      expect(connection).to have_received(:post).with(
+        '/accounts/123/close',
+        {
+          data: {
+            type: 'walletAccountClose',
+            attributes: {
+              reason: 'ByCustomer'
+            }
+          }
+        }
+      )
+    end
+
+    it 'updates the account with the response' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.close('ByCustomer')
+
+      expect(account.close_reason).to eq 'ByCustomer'
+    end
+
+    it 'handles nil reason' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.close(nil)
+
+      expect(connection).to have_received(:post).with(
+        '/accounts/123/close',
+        {
+          data: {
+            type: 'walletAccountClose',
+            attributes: {}
+          }
+        }
+      )
+    end
+  end
+
+  describe '#freeze' do
+    let(:connection) { instance_double(Unit::Connection) }
+    let(:response_body) do
+      {
+        id: '123',
+        type: 'walletAccount',
+        attributes: {
+          freeze_reason: 'Fraud',
+          status: 'Frozen'
+        }
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:post).and_return(response_body)
+    end
+
+    it 'calls the freeze endpoint with reason and reason_text' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.freeze('Fraud', 'Suspicious activity detected')
+
+      expect(connection).to have_received(:post).with(
+        '/accounts/123/freeze',
+        {
+          data: {
+            type: 'walletAccountFreeze',
+            attributes: {
+              reason: 'Fraud',
+              reasonText: 'Suspicious activity detected'
+            }
+          }
+        }
+      )
+    end
+
+    it 'updates the account with the response' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.freeze('Fraud', 'Suspicious activity detected')
+
+      expect(account.freeze_reason).to eq 'Fraud'
+    end
+
+    it 'handles nil values with compact' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.freeze(nil, nil)
+
+      expect(connection).to have_received(:post).with(
+        '/accounts/123/freeze',
+        {
+          data: {
+            type: 'walletAccountFreeze',
+            attributes: {}
+          }
+        }
+      )
+    end
+  end
+
+  describe '#unfreeze' do
+    let(:connection) { instance_double(Unit::Connection) }
+    let(:response_body) do
+      {
+        id: '123',
+        type: 'walletAccount',
+        attributes: {
+          freeze_reason: nil,
+          status: 'Open'
+        }
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:post).and_return(response_body)
+    end
+
+    it 'calls the unfreeze endpoint' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.unfreeze
+
+      expect(connection).to have_received(:post).with(
+        '/accounts/123/unfreeze'
+      )
+    end
+
+    it 'updates the account with the response' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.unfreeze
+
+      expect(account.freeze_reason).to be_nil
+    end
+  end
+
+  describe '#reopen' do
+    let(:connection) { instance_double(Unit::Connection) }
+    let(:response_body) do
+      {
+        id: '123',
+        type: 'walletAccount',
+        attributes: {
+          close_reason: nil,
+          status: 'Open'
+        }
+      }
+    end
+
+    before do
+      allow(described_class).to receive(:connection).and_return(connection)
+      allow(connection).to receive(:post).and_return(response_body)
+    end
+
+    it 'calls the reopen endpoint' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.reopen
+
+      expect(connection).to have_received(:post).with(
+        '/accounts/123/reopen'
+      )
+    end
+
+    it 'updates the account with the response' do
+      account = described_class.new(
+        wallet_terms: wallet_terms
+      )
+      account.id = '123'
+
+      account.reopen
+
+      expect(account.close_reason).to be_nil
+    end
+  end
+
+  describe '#as_json_api' do
+    it 'includes all non-readonly attributes' do
+      result = subject.as_json_api
+
+      expect(result).to include(:wallet_terms)
+    end
+
+    it 'excludes readonly attributes' do
+      result = subject.as_json_api
+
+      expect(result).not_to include(:created_at)
+      expect(result).not_to include(:updated_at)
+      expect(result).not_to include(:name)
+      expect(result).not_to include(:routing_number)
+      expect(result).not_to include(:account_number)
+      expect(result).not_to include(:deposit_product)
+      expect(result).not_to include(:currency)
+      expect(result).not_to include(:balance)
+      expect(result).not_to include(:hold)
+      expect(result).not_to include(:available)
+      expect(result).not_to include(:freeze_reason)
+      expect(result).not_to include(:close_reason)
+      expect(result).not_to include(:fraud_status)
+      expect(result).not_to include(:data_status)
+    end
+
+    it 'includes optional attributes when present' do
+      account = described_class.new(
+        wallet_terms: wallet_terms,
+        tags: { key: 'value' }
+      )
+
+      result = account.as_json_api
+      expect(result).to include(:tags)
+    end
+  end
+end
+


### PR DESCRIPTION
[MM-181](https://linear.app/thatch/issue/MM-181/build-out-client-layer-for-creating-applications-and-wallets)

Adds the `Unit::WalletAccount` resource so that we can create, freeze, un-freeze, close, and re-open Wallet FBO accounts.