### PR TITLE
Add back V1 Business Application fields

### DIFF
--- a/lib/unit-ruby/business_application.rb
+++ b/lib/unit-ruby/business_application.rb
@@ -24,6 +24,13 @@ module Unit
         attribute :beneficial_owners, Types::Array # Beneficial owners of the business
         attribute :year_of_incorporation, Types::String # Year of incorporation of the business
         attribute :countries_of_operation, Types::Array # Array of ISO 3166-1 Alpha-2 country codes
+        attribute :stock_symbol, Types::String # Required if entity_type is PubliclyTradedCorporation
+        attribute :business_vertical, Types::BusinessVertical # The vertical of the business
+        attribute :industry, Types::Industry  # Optional
+        attribute :annual_revenue, Types::String # Optional, required if any officer or beneficial owner has non-US nationality
+        attribute :number_of_employees, Types::String # Optional, required if any officer or beneficial owner has non-US nationality
+        attribute :cash_flow, Types::String # Optional, required if any officer or beneficial owner has non-US nationality
+        attribute :countries_of_operation, Types::Array # Optional, required if any officer or beneficial owner has non-US nationality
 
         # V2 fields
         attribute :source_of_funds, Types::String # Primary source of funds of the business


### PR DESCRIPTION
## Motivation
Unit/Thread have updated their Business Application to V2 which requiring new fields in addition to the ones we already provide today. They have [recommended](https://thatchhealth.slack.com/archives/C04091QRAE8/p1774276436277319?thread_ts=1772038619.033059&cid=C04091QRAE8) that all new applications include both V1 and V2 fields while we migrate to the new flow.

This PR adds back these V1 fields, which were removed [here](https://github.com/thatch-health/unit-ruby/commits/main/).

## Summary
Adds back V1 application fields to our Unit Business Application object so that we can more seamlessly migrate to V2.